### PR TITLE
Fixes static analyzer complaints about CHDictionaryDescription

### DIFF
--- a/CHDataStructures.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/CHDataStructures.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:CHDataStructures.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/source/CHMutableDictionary.h
+++ b/source/CHMutableDictionary.h
@@ -12,7 +12,7 @@
 
 #import "Util.h"
 
-HIDDEN void createCollectableCFMutableDictionary(CFMutableDictionaryRef* dictionary, NSUInteger initialCapacity);
+HIDDEN void createCollectableCFMutableDictionary(__strong CFMutableDictionaryRef* dictionary, NSUInteger initialCapacity);
 
 /**
  @file CHMutableDictionary.h

--- a/source/CHMutableDictionary.m
+++ b/source/CHMutableDictionary.m
@@ -22,8 +22,8 @@ void CHDictionaryRelease(CFAllocatorRef allocator, const void *value) {
 	[(id)value release];
 }
 
-CFStringRef CHDictionaryDescription(const void *value) {
-	return CFRetain([(id)value description]);
+CFStringRef CHDictionaryCopyDescription(const void *value) {
+	return (CFStringRef)[[(id)value description] copy];
 }
 
 Boolean CHDictionaryEqual(const void *value1, const void *value2) {
@@ -38,7 +38,7 @@ static const CFDictionaryKeyCallBacks kCHDictionaryKeyCallBacks = {
 	0, // default version
 	CHDictionaryRetain,
 	CHDictionaryRelease,
-	CHDictionaryDescription,
+	CHDictionaryCopyDescription,
 	CHDictionaryEqual,
 	CHDictionaryHash
 };
@@ -47,7 +47,7 @@ static const CFDictionaryValueCallBacks kCHDictionaryValueCallBacks = {
 	0, // default version
 	CHDictionaryRetain,
 	CHDictionaryRelease,
-	CHDictionaryDescription,
+	CHDictionaryCopyDescription,
 	CHDictionaryEqual
 };
 


### PR DESCRIPTION
I changed the implementation of CHDictionaryDescription to actually return a copy of the description. It is supposed to do this according to the API. I also changed the name of the function so it matches the naming conventions that the static analyzer expects.