### PR TITLE
Requesting empty subsets causes nil arg exceptions

### DIFF
--- a/source/CHAbstractBinarySearchTree.m
+++ b/source/CHAbstractBinarySearchTree.m
@@ -606,10 +606,12 @@ CHBinaryTreeNode* CHCreateBinaryTreeNodeWithObject(id anObject) {
 			while ((anObject = [e nextObject]) &&
 				   [anObject compare:start] == NSOrderedAscending)
 				;
-			do {
-				[subset addObject:anObject];
-			} while ((anObject = [e nextObject]) &&
-					 [anObject compare:end] != NSOrderedDescending);
+            if (anObject) {
+                do {
+                    [subset addObject:anObject];
+                } while ((anObject = [e nextObject]) &&
+                         [anObject compare:end] != NSOrderedDescending);
+            }
 		}
 		else {
 			// Include subset of objects NOT between the range parameters.

--- a/test/CHSortedSetTest.m
+++ b/test/CHSortedSetTest.m
@@ -322,6 +322,17 @@ static NSArray *abcde;
 	subset = [[set subsetFromObject:@"A" toObject:@"G" options:0] allObjects];
 	STAssertEqualObjects(subset, acdeg, nil);
 	
+    // Test including no objects
+    subset = [[set subsetFromObject:@"H" toObject:@"I" options:0] allObjects];
+    STAssertEquals([subset count], 0ul, nil);
+    subset = [[set subsetFromObject:@"A" toObject:@"B"
+               options:CHSubsetExcludeHighEndpoint|CHSubsetExcludeLowEndpoint] allObjects];
+    STAssertEquals([subset count], 0ul, nil);
+    subset = [[set subsetFromObject:@"H" toObject:@"A" options:CHSubsetExcludeHighEndpoint] allObjects];
+    STAssertEquals([subset count], 0ul, nil);
+    subset = [[set subsetFromObject:@"H" toObject:@"" options:0] allObjects];
+    STAssertEquals([subset count], 0ul, nil);
+    
 	// Test excluding elements at the end
 	subset = [[set subsetFromObject:nil toObject:@"F" options:0] allObjects];
 	STAssertEqualObjects(subset, acde, nil);


### PR DESCRIPTION
When requesting a subsetFromObject:toObject: that starts after the last object, it tries to add a nil object to the class, causing an exception. This simple fix adds a check for anObject before starting to look for the end of the subset.

-----

Added test cases for subsetFromObject:toObject:... that demonstrate the problem
and validate other empty selections. Check to make sure anObject is still valid
after finding our start position.